### PR TITLE
Implementado cache de produtos

### DIFF
--- a/ms-orders/src/main/java/br/com/jfood/ms_orders/OrdersMsApplication.java
+++ b/ms-orders/src/main/java/br/com/jfood/ms_orders/OrdersMsApplication.java
@@ -3,9 +3,11 @@ package br.com.jfood.ms_orders;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableScheduling
 public class OrdersMsApplication {
 
     public static void main(String[] args) {

--- a/ms-orders/src/main/java/br/com/jfood/ms_orders/dto/PageResponseDTO.java
+++ b/ms-orders/src/main/java/br/com/jfood/ms_orders/dto/PageResponseDTO.java
@@ -41,6 +41,9 @@ public class PageResponseDTO<T> {
     private int totalPages;
     private boolean last;
 
+    public PageResponseDTO() {
+    }
+
     public PageResponseDTO(Page<T> page) {
         this.content = page.getContent();
         this.pageNumber = page.getNumber();

--- a/ms-orders/src/main/java/br/com/jfood/ms_orders/service/ProductCacheService.java
+++ b/ms-orders/src/main/java/br/com/jfood/ms_orders/service/ProductCacheService.java
@@ -1,0 +1,71 @@
+package br.com.jfood.ms_orders.service;
+
+import br.com.jfood.ms_orders.dto.PageResponseDTO;
+import br.com.jfood.ms_orders.dto.ProductResponseDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ProductCacheService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProductCacheService.class);
+
+    private final RestTemplate restTemplate;
+    private final String productListApiUrl;
+
+    // When a thread changes the value of a variable, other threads see the change immediately.
+    // Without volatile, the value may be cached locally to the thread, causing inconsistencies in concurrent readings.
+    private static volatile List<ProductResponseDTO> cachedProducts = Collections.emptyList();
+
+    public ProductCacheService(RestTemplate restTemplate, @Value("${product.api.list-url}") String productListApiUrl) {
+        if (productListApiUrl == null || productListApiUrl.isEmpty()) {
+            throw new IllegalArgumentException("Missing configuration: 'product.api.list-url' must be set.");
+        }
+        this.restTemplate = restTemplate;
+        this.productListApiUrl = productListApiUrl;
+    }
+
+    @Scheduled(fixedDelayString = "#{${scheduler.products.refresh.minutes:60} * 60000}")
+    public void fetchProducts() {
+        try {
+            logger.debug("Fetching product list from {}", productListApiUrl);
+
+            ResponseEntity<PageResponseDTO<ProductResponseDTO>> response = restTemplate.exchange(
+                    productListApiUrl,
+                    HttpMethod.GET,
+                    null,
+                    new ParameterizedTypeReference<PageResponseDTO<ProductResponseDTO>>() {
+                    }
+            );
+
+            List<ProductResponseDTO> products = Optional.ofNullable(response.getBody())
+                    .map(PageResponseDTO::getContent)
+                    .orElse(Collections.emptyList());
+
+            if (products.isEmpty()) {
+                logger.warn("Fetched product list is empty.");
+            } else {
+                cachedProducts = products;
+                logger.info("Product list updated. Total products: [{}].", products.size());
+            }
+
+        } catch (Exception e) {
+            logger.error("Failed to fetch product list from {}: {}", productListApiUrl, e.getMessage());
+        }
+    }
+
+    public static List<ProductResponseDTO> getCachedProducts() {
+        return cachedProducts;
+    }
+}

--- a/ms-orders/src/main/java/br/com/jfood/ms_orders/versionlogger/VersionLogger.java
+++ b/ms-orders/src/main/java/br/com/jfood/ms_orders/versionlogger/VersionLogger.java
@@ -22,7 +22,7 @@ public class VersionLogger {
     @PostConstruct
     private void postConstruct() {
         final String CURRENT_NUMBER_VERSION = "1.0.0";
-        final String CURRENT_DATE_VERSION = "01-Mai-2025";
+        final String CURRENT_DATE_VERSION = "03-Mai-2025";
 
         logger.info("JFOOD - MS-ORDERS - STARTING - Version: {} - {}", CURRENT_NUMBER_VERSION, CURRENT_DATE_VERSION);
     }

--- a/ms-orders/src/main/resources/application.properties
+++ b/ms-orders/src/main/resources/application.properties
@@ -26,8 +26,15 @@ spring.flyway.baseline-on-migrate=true
 # Keycloak configuration
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:7001/realms/JFood
 
-# Product information address
+# Product list endpoint
+product.api.list-url=http://localhost:8082/ms-products/products
+
+# Product detail endpoint
 product.api.url=http://localhost:8082/ms-products/products/{id}
+
+# Intervalo de atualização da lista de produtos (em minutos)
+scheduler.products.refresh.minutes=1
+
 
 ###############################
 # CIRCUIT BREAKER CONFIGURATION


### PR DESCRIPTION
- Implementação de cache de produtos para ser usado pelo serviço `ms-orders` quando o circuit breaker detectar que o serviço `ms-products` não estiver respondendo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automatic scheduled refreshing of product data from an external API.
  - Added a new service for managing and caching product lists, improving product data availability and resilience.
- **Bug Fixes**
  - Improved error handling and fallback logic for product price retrieval, now leveraging cached product data when the API is unavailable.
- **Configuration**
  - Added new properties for product list API URL and scheduler refresh interval.
- **Other**
  - Updated version date displayed at application startup.
  - Minor constructor and documentation adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->