### PR TITLE
Configuração de Rate Limiting no API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A autenticação é realizada utilizando o **Keycloak**, com suporte à geraçã
    | SonarQube   | http://localhost:7002   | admin / admin               |
    | Jenkins     | http://localhost:7003   | senha gerada no container   |
    | RabbitMQ    | http://localhost:15672  | `guest`/`guest`             |
+   | Redis       | http://localhost:6379   |                             |
 
    **Para parar e remover os containers:**
    ```sh

--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -1,16 +1,28 @@
 # API Gateway
 
-Este é o serviço **API Gateway** do projeto **jFood**, responsável por atuar como **ponto de entrada único** para todas as requisições externas, roteando dinamicamente as chamadas para os microsserviços registrados no **Eureka Server**.
+Este é o serviço **API Gateway** do projeto **JFood**, responsável por atuar como **ponto de entrada único** para todas as requisições externas, roteando dinamicamente as chamadas para os microsserviços registrados no **Eureka Server**.
 
----
+Além do roteamento, o Gateway também implementa rate limiting para controlar o número de requisições por IP, utilizando o Redis como armazenamento rápido para esse controle.
+
+## ⚠️ Pré-requisitos importantes
+
+Para que o mecanismo de rate limiting funcione corretamente, o serviço Redis precisa estar em execução antes de subir o API Gateway.
+
+Você pode iniciar um container Redis localmente com o seguinte comando:
+
+```
+docker run -d --name redis -p 6379:6379 redis
+```
+> Certifique-se de que a porta `6379` esteja disponível e que nenhum outro serviço Redis esteja em execução.
+
 ## 🚀 Ordem de execução
 
 > Atenção à ordem de inicialização dos serviços para garantir o funcionamento correto:
 
 1. [Service Registry - Eureka Server](https://github.com/oluizeduardo/jfood/tree/main/ms-service-registry)
-2. API Gateway (api-gateway)
-3. Demais microsserviços (ex: ms-users, ms-notification, etc.)
----
+2. Redis (necessário para o rate limiting do Gateway)
+3. API Gateway (api-gateway)
+4. Demais microsserviços (ex: ms-users, ms-notification, etc.)
 
 ## 🛠️ Execução
 
@@ -26,6 +38,3 @@ cd jfood/api-gateway
 # 3. Compile e execute a aplicação
 mvn spring-boot:run
 ```
-
-
-

--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>spring-cloud-starter-gateway</artifactId>
         </dependency>
 
+        <!-- SPRING REDIS -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis-reactive</artifactId>
+        </dependency>
+
         <!-- EUREKA CLIENT -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/api-gateway/src/main/java/br/com/jfood/api_gateway/config/RateLimiterConfig.java
+++ b/api-gateway/src/main/java/br/com/jfood/api_gateway/config/RateLimiterConfig.java
@@ -1,0 +1,16 @@
+package br.com.jfood.api_gateway.config;
+
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Mono;
+
+@Configuration
+public class RateLimiterConfig {
+
+    @Bean
+    public KeyResolver ipKeyResolver() {
+        return exchange -> Mono.just(
+                exchange.getRequest().getRemoteAddress().getAddress().getHostAddress());
+    }
+}

--- a/api-gateway/src/main/java/br/com/jfood/api_gateway/versionlogger/VersionLogger.java
+++ b/api-gateway/src/main/java/br/com/jfood/api_gateway/versionlogger/VersionLogger.java
@@ -22,7 +22,7 @@ public class VersionLogger {
     @PostConstruct
     private void postConstruct() {
         final String CURRENT_NUMBER_VERSION = "1.0.0";
-        final String CURRENT_DATE_VERSION = "26-Apr-2025";
+        final String CURRENT_DATE_VERSION = "03-May-2025";
 
         logger.info("JFOOD - API GATEWAY - STARTING - Version: {} - {}", CURRENT_NUMBER_VERSION, CURRENT_DATE_VERSION);
     }

--- a/api-gateway/src/main/resources/application.properties
+++ b/api-gateway/src/main/resources/application.properties
@@ -27,3 +27,34 @@ management.endpoints.web.exposure.include=*
 management.endpoint.gateway.enabled=true
 management.endpoint.health.show-details=always
 management.endpoints.web.base-path=/actuator
+
+############################
+# RATE LIMITER CONFIGURATION
+############################
+
+# Redis connection
+spring.redis.host=localhost
+spring.redis.port=6379
+
+# Spring Cloud Gateway default filter - rate limiting
+spring.cloud.gateway.default-filters[0].name=RequestRateLimiter
+spring.cloud.gateway.default-filters[0].args.redis-rate-limiter.replenishRate=1
+spring.cloud.gateway.default-filters[0].args.redis-rate-limiter.burstCapacity=1
+spring.cloud.gateway.default-filters[0].args.key-resolver=#{@ipKeyResolver}
+
+# Gateway routes
+spring.cloud.gateway.routes[0].id=orders
+spring.cloud.gateway.routes[0].uri=lb://ms-orders
+spring.cloud.gateway.routes[0].predicates[0]=Path=/ms-orders/**
+spring.cloud.gateway.routes[0].filters[0]=StripPrefix=1
+
+spring.cloud.gateway.routes[1].id=products
+spring.cloud.gateway.routes[1].uri=lb://ms-products
+spring.cloud.gateway.routes[1].predicates[0]=Path=/ms-products/**
+spring.cloud.gateway.routes[1].filters[0]=StripPrefix=1
+
+spring.cloud.gateway.routes[2].id=users
+spring.cloud.gateway.routes[2].uri=lb://ms-users
+spring.cloud.gateway.routes[2].predicates[0]=Path=/ms-users/**
+spring.cloud.gateway.routes[2].filters[0]=StripPrefix=1
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,14 @@ services:
     networks:
       - jfood_net
 
+  redis:
+    image: redis:7-alpine
+    container_name: my-redis
+    ports:
+      - "6379:6379"
+    networks:
+      - jfood_net 
+
 volumes:
   pg_data:
   jenkins_home:

--- a/ms-notification/README.md
+++ b/ms-notification/README.md
@@ -10,6 +10,14 @@ Este serviço atua exclusivamente como um consumidor da fila, e só realiza envi
 - 🗑️ Simulação de envio de e-mail de **confirmação de exclusão de conta** quando um usuário é removido
 - 🔁 Consumo assíncrono de eventos da fila do **RabbitMQ**
 
+## 🚀 Ordem de execução
+
+> Atenção à ordem de inicialização dos serviços para garantir o funcionamento correto:
+
+1. [Service Registry - Eureka Server](https://github.com/oluizeduardo/jfood/tree/main/ms-service-registry)
+2. API Gateway (api-gateway)
+3. Demais microsserviços (ex: ms-users, ms-notification, etc.)
+
 ## 🛠️ Configuração e Execução
 
 ### Rodando localmente

--- a/ms-orders/README.md
+++ b/ms-orders/README.md
@@ -20,7 +20,7 @@ Microsserviço responsável pelo **cadastro e gerenciamento de pedidos de compra
 
 Todas as operações do **ms-orders** exigem que o usuário esteja **autenticado via Keycloak**.
 
-- O token JWT deve ser fornecido no cabeçalho Authentication Bearer das requisições.
+- O token JWT deve ser fornecido no cabeçalho `Authentication: Bearer` das requisições.
 - O token deve conter informações do usuário autenticado, que será associado ao pedido.
 
 ## 🛠️ Configuração e Execução

--- a/ms-orders/README.md
+++ b/ms-orders/README.md
@@ -2,18 +2,23 @@
 
 Microsserviço responsável pelo **cadastro e gerenciamento de pedidos de compra** realizados pelos usuários na aplicação **JFood**. 
 
-Sempre que um novo pedido é criado com sucesso, o serviço publica um **evento na fila RabbitMQ**, permitindo que outros microserviços (como notificações, faturamento, etc.) reajam de forma assíncrona a esse evento.
-
 ## ⚙️ Funcionalidades
 
 - 🛒 Criação de novos pedidos de compra
 - 📦 Consulta de pedidos por usuário
 - 🧾 Detalhamento de um pedido específico
-- 📤 Emissão de evento na **fila RabbitMQ** após o registro do pedido
+
+## 🚀 Ordem de execução
+
+> Atenção à ordem de inicialização dos serviços para garantir o funcionamento correto:
+
+1. [Service Registry - Eureka Server](https://github.com/oluizeduardo/jfood/tree/main/ms-service-registry)
+2. API Gateway (api-gateway)
+3. Demais microsserviços (ex: ms-users, ms-notification, etc.)
 
 ## 🔐 Autenticação
 
-Todas as operações do **Orders-MS** exigem que o usuário esteja **autenticado via Keycloak**.
+Todas as operações do **ms-orders** exigem que o usuário esteja **autenticado via Keycloak**.
 
 - O token JWT deve ser fornecido no cabeçalho Authentication Bearer das requisições.
 - O token deve conter informações do usuário autenticado, que será associado ao pedido.
@@ -26,7 +31,7 @@ Todas as operações do **Orders-MS** exigem que o usuário esteja **autenticado
 # 1. Clone o repositório
 git clone https://github.com/oluizeduardo/jfood.git
 
-# 2. Acesse a pasta do serviço de usuários.
+# 2. Acesse a pasta do serviço
 cd jfood/ms-orders
 
 # 3. Compile e execute a aplicação

--- a/ms-products/README.md
+++ b/ms-products/README.md
@@ -6,15 +6,23 @@ O serviço oferece endpoints públicos e privados, permitindo tanto a listagem a
 
 ## ⚙️ Funcionalidades
 
-- 📋 Listagem pública de produtos disponíveis (`GET /products`) — não requer autenticação
+- 📋 Listagem pública de produtos disponíveis (`GET /products`) — não requer autenticação.
 
-- 🔎 Consulta de detalhes de um produto específico (`GET /products/{id}`) — requer autenticação
+- 🔎 Consulta de detalhes de um produto específico (`GET /products/{id}`) — não requer autenticação.
 
-- 🛠️ Cadastro, atualização e exclusão de produtos — requer autenticação
+- 🛠️ Cadastro, atualização e exclusão de produtos — requer autenticação.
+
+## 🚀 Ordem de execução
+
+> Atenção à ordem de inicialização dos serviços para garantir o funcionamento correto:
+
+1. [Service Registry - Eureka Server](https://github.com/oluizeduardo/jfood/tree/main/ms-service-registry)
+2. API Gateway (api-gateway)
+3. Demais microsserviços (ex: ms-users, ms-notification, etc.)
 
 ## 🔐 Autenticação
 
-As operações no `MS-Products` seguem a seguinte política de autenticação:
+As operações no `ms-products` seguem a seguinte política de autenticação:
 - As rotas para listagem geral de produtos (`GET /products`), e detalhes de um produto específico (`GET /products/{id}`) são públicas e pode ser acessada sem token.
 - Operações de criação, atualização e remoção de produtos exigem autenticação via Keycloak.
 > O token JWT deve ser enviado no cabeçalho **Authorization Bearer** das requisições privadas.
@@ -27,7 +35,7 @@ As operações no `MS-Products` seguem a seguinte política de autenticação:
 # 1. Clone o repositório
 git clone https://github.com/oluizeduardo/jfood.git
 
-# 2. Acesse a pasta do serviço de usuários.
+# 2. Acesse a pasta do serviço
 cd jfood/ms-products
 
 # 3. Compile e execute a aplicação

--- a/ms-service-registry/README.md
+++ b/ms-service-registry/README.md
@@ -6,13 +6,21 @@ Este projeto é um **Service Registry** criado com **Spring Cloud Eureka Server*
 
 Este serviço permite que microsserviços se registrem dinamicamente e descubram uns aos outros, promovendo **desacoplamento**, **escalabilidade** e **tolerância a falhas** dentro da arquitetura.
 
+## 🚀 Ordem de execução
+
+> Atenção à ordem de inicialização dos serviços para garantir o funcionamento correto:
+
+1. Service Registry - Eureka Server
+2. [API Gateway (api-gateway)](https://github.com/oluizeduardo/jfood/tree/main/api-gateway)
+3. Demais microsserviços (ex: ms-users, ms-notification, etc.)
+
 ## ⚙️ Executando localmente
 
 ```bash
 # 1. Clone o repositório
 git clone https://github.com/oluizeduardo/jfood.git
 
-# 2. Acesse a pasta do serviço.
+# 2. Acesse a pasta do serviço
 cd jfood/ms-service-registry
 
 # 3. Compile e execute a aplicação

--- a/ms-users/README.md
+++ b/ms-users/README.md
@@ -2,8 +2,6 @@
 
 Microsserviço responsável pela gestão de usuários dentro da aplicação **JFood**. Ele oferece funcionalidades como cadastro, consulta e exclusão de usuários, além de realizar a integração com o **Keycloak** para registro e autenticação.
 
-Este microserviço é parte essencial da arquitetura distribuída da aplicação **JFood**, garantindo o gerenciamento seguro e eficiente dos usuários.
-
 ## ⚙️ Funcionalidades
 
 - 📋 Cadastro de novos usuários
@@ -11,37 +9,26 @@ Este microserviço é parte essencial da arquitetura distribuída da aplicação
 - ❌ Exclusão de usuários
 - 🔐 Cadastro automático de usuários no **Keycloak** para autenticação e autorização
 
-## 🧱 Estrutura de Pacotes
+## 🚀 Ordem de execução
 
-Este microserviço segue as boas práticas de desenvolvimento com **Spring Boot**, organizando o código em camadas bem definidas:
+> Atenção à ordem de inicialização dos serviços para garantir o funcionamento correto:
 
-- `amqp` – Responsável pela configuração e comunicação com a fila do **RabbitMQ**
-- `config` – Contém as configurações gerais da aplicação, incluindo segurança, ExceptionHandlers, e beans customizados
-- `controller` – Define os endpoints REST e lida com as requisições da camada de apresentação
-- `dto` – Objetos de transferência de dados utilizados na comunicação entre camadas
-- `model` – Entidades de domínio que representam as tabelas do banco de dados
-- `repository` – Interfaces de acesso a dados, utilizando o **Spring Data JPA**
-- `service` – Contém a lógica de negócio e orquestra as operações do sistema
-- `versionlogger` – Componente responsável por exibir logs com informações da versão da aplicação durante a inicialização
+1. [Service Registry - Eureka Server](https://github.com/oluizeduardo/jfood/tree/main/ms-service-registry)
+2. [API Gateway (api-gateway)](https://github.com/oluizeduardo/jfood/tree/main/api-gateway)
+3. Demais microsserviços (ex: ms-users, ms-notification, etc.)
 
 ## ⚙️ Executando localmente
-
 ```bash
-# 1. Clone o repositório.
+# 1. Clone o repositório
 git clone https://github.com/oluizeduardo/jfood.git
 
-# 2. Inicie o Eureka Service Registry.
-cd jfood/ms-service-registry
-mvn spring-boot:run
-
-# 3. Acesse a pasta do serviço.
+# 2. Acesse a pasta do serviço
 cd jfood/ms-users
 
-# 4. Compile e execute a aplicação.
-# As migrações do Flyway vão executar automaticamente ao subir a aplicação
+# 3. Compile e execute a aplicação
 mvn spring-boot:run
 ```
----
+
 
 ## 📬 Postman Collection
 


### PR DESCRIPTION
Este PR adiciona suporte a rate limiting no serviço API Gateway utilizando o Redis como armazenamento para controle de requisições por IP. A implementação utiliza o `RedisRateLimiter` do Spring Cloud Gateway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced rate limiting at the API Gateway level, using Redis to track request counts per IP.
  - Added explicit route configurations for orders, products, and users services in the API Gateway.

- **Chores**
  - Added Redis as a new auxiliary service in Docker Compose and updated documentation to include Redis setup instructions.
  - Updated all relevant READMEs to clarify the required startup order for system components.
  - Improved documentation consistency and minor formatting across multiple services.

- **Bug Fixes**
  - Corrected the authentication requirement for the product detail endpoint to be publicly accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->