### PR TITLE
Atualizado porta do RabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A autenticação é realizada utilizando o **Keycloak**, com suporte à geraçã
    | Keycloak    | http://localhost:7001   | conforme `.env`             |   
    | SonarQube   | http://localhost:7002   | admin / admin               |
    | Jenkins     | http://localhost:7003   | senha gerada no container   |
-   | RabbitMQ    | http://localhost:15672  | `guest`/`guest`             |
+   | RabbitMQ    | http://localhost:7004   | `guest`/`guest`             |
    | Redis       | http://localhost:6379   |                             |
 
    **Para parar e remover os containers:**


### PR DESCRIPTION
Atualiza o número da porta na URL de acesso ao RabbitMQ em localhost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the RabbitMQ service access URL in installation guidelines. Users should now use the new endpoint for service access; login credentials remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->